### PR TITLE
📝 Docs: Add comprehensive docstrings for main functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Project Conventions & Operational Memory
+
+This file serves as the source of truth for repository conventions and operational memory.
+
+## Codebase Layout
+- `cmd/send2kindle/` -> Main application entrypoint and logic for converting and emailing files.
+- `cmd/send2kindle/utils.go` -> Shared utilities, logging, and centralized error handling functions (`Fatalf`, `MustSucess`).
+- `cmd/send2kindle/cleanup.go` -> Temporary file management and cleanup hooks.
+- `cmd/send2kindle/mail.go` -> Email composition and sending logic (SMTP).
+- `cmd/send2kindle/convert.go` -> Wraps `ebook-convert` for format conversions.
+- `cmd/send2kindle/main.go` -> CLI flag parsing and application coordination.
+- `package.nix`, `shell.nix`, `default.nix` -> Nix packaging definitions.
+
+## Conventions
+- **Error Handling:** Use the centralized error handling functions in `cmd/send2kindle/utils.go` (`Fatalf`, `MustSucess`). Do not silently ignore errors or call `panic` directly unless strictly necessary. Ensure errors provide adequate context before program termination.
+- **Task Management:** The project uses `mise` for task execution. Always use `mise run` for commands. Ensure all required tool versions are pinned in `.mise.toml` or `mise.toml`.
+- **Code Quality:** Use standard Go tooling (`go vet ./...`, `gofmt -s -w .`). These are mapped to `mise run lint`.
+- **CI/CD:** The repository uses a single GitHub Actions workflow (`.github/workflows/autorelease.yml`) for installation, codegen, CI, and releases.
+
+## Memory / Context
+- The project is a Go 1.15 application.
+- Uses `mise` for task management; wildcard dependencies are used for group tasks.
+- Ensure dependencies are never downgraded without explicit instruction.

--- a/cmd/send2kindle/cleanup.go
+++ b/cmd/send2kindle/cleanup.go
@@ -8,26 +8,35 @@ import (
 	"github.com/google/uuid"
 )
 
+// CreateTempFileName generates a unique filepath in the system's temporary directory
+// with the requested extension. It automatically registers a cleanup hook to guarantee
+// the file's deletion once processing finishes, minimizing storage leaks.
 func CreateTempFileName(extension string) (filename string) {
-    tmpdir := os.TempDir()
-    generatedName := uuid.New().String()
-    filename = path.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
-    AddCleanupHook(func() {
-        os.Remove(filename)
-    })
-    return filename
+	tmpdir := os.TempDir()
+	generatedName := uuid.New().String()
+	filename = path.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
+	AddCleanupHook(func() {
+		os.Remove(filename)
+	})
+	return filename
 }
 
 var (
-    cleanupHooks = []func(){}
+	cleanupHooks = []func(){}
 )
 
+// AddCleanupHook queues a function to be executed during the teardown phase.
+// It is intended to defer temporary file removal and resource deallocation until
+// the core email dispatch process concludes.
 func AddCleanupHook(f func()) {
-    cleanupHooks = append(cleanupHooks, f)
+	cleanupHooks = append(cleanupHooks, f)
 }
 
+// Cleanup iterates over all registered teardown functions and executes them sequentially.
+// Designed to be called as a defer at the start of the program's entrypoint, ensuring
+// cleanup occurs even if intermediate conversion or network steps fail.
 func Cleanup() {
-    for _, f := range cleanupHooks {
-        f()
-    }
+	for _, f := range cleanupHooks {
+		f()
+	}
 }

--- a/cmd/send2kindle/convert.go
+++ b/cmd/send2kindle/convert.go
@@ -1,8 +1,11 @@
 package main
 
+// ConvertToEPUB takes an existing file path and invokes the external 'ebook-convert'
+// binary to generate an EPUB version of the book. The resulting file is stored in the OS
+// temp directory and will be cleaned up automatically during application shutdown.
 func ConvertToEPUB(filename string) string {
-    outputFileName := CreateTempFileName("epub")
-    Log("Converting '%s' to '%s'", filename, outputFileName)
-    MustSucess(Command("ebook-convert", filename, outputFileName))
-    return outputFileName
+	outputFileName := CreateTempFileName("epub")
+	Log("Converting '%s' to '%s'", filename, outputFileName)
+	MustSucess(Command("ebook-convert", filename, outputFileName))
+	return outputFileName
 }

--- a/cmd/send2kindle/mail.go
+++ b/cmd/send2kindle/mail.go
@@ -8,34 +8,41 @@ import (
 	"github.com/scorredoira/email"
 )
 
+// Email encapsulates the routing and payload structure of a single message,
+// consisting of a destination address and an array of absolute local file paths to attach.
 type Email struct {
-    To string
-    Files []string
+	To    string
+	Files []string
 }
 
+// EmailAuthenticationData holds the required configuration for the outbound SMTP connection.
+// 'Server' usually includes the domain and port (e.g. smtp.gmail.com:587).
 type EmailAuthenticationData struct {
-    Server string
-    User string
-    Password string
+	Server   string
+	User     string
+	Password string
 }
 
+// SendEmail establishes an authenticated session with an external SMTP host
+// and iteratively builds/transmits multipart MIME messages containing the requested ebook files.
+// Network, authentication, or filesystem IO errors bubble up directly from the underlying libraries.
 func SendEmail(s EmailAuthenticationData, msgs ...Email) error {
-    serverOnly := strings.Split(s.Server, ":")[0]
-    auth := smtp.PlainAuth("", s.User, s.Password, serverOnly)
-    for _, msg := range msgs {
-        m := email.NewMessage("", "")
-        m.To = []string{msg.To}
-        m.From = mail.Address{Name: "", Address: s.User}
-        for _, file := range msg.Files {
-            err := m.Attach(file)
-            if err != nil {
-                return err
-            }
-        }
-        err := email.Send(s.Server, auth, m)
-        if err != nil {
-            return err
-        }
-    }
-    return nil
+	serverOnly := strings.Split(s.Server, ":")[0]
+	auth := smtp.PlainAuth("", s.User, s.Password, serverOnly)
+	for _, msg := range msgs {
+		m := email.NewMessage("", "")
+		m.To = []string{msg.To}
+		m.From = mail.Address{Name: "", Address: s.User}
+		for _, file := range msg.Files {
+			err := m.Attach(file)
+			if err != nil {
+				return err
+			}
+		}
+		err := email.Send(s.Server, auth, m)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/send2kindle/main.go
+++ b/cmd/send2kindle/main.go
@@ -7,62 +7,68 @@ import (
 )
 
 var ( // Authentication parameters
-    SMTP_USER = ""
-    SMTP_PASSWD = ""
-    SMTP_SERVER = ""
-    KINDLE_EMAIL = ""
+	SMTP_USER    = ""
+	SMTP_PASSWD  = ""
+	SMTP_SERVER  = ""
+	KINDLE_EMAIL = ""
 )
 
 var (
-    books = []string{}
-    convertToEPUB = false
+	books         = []string{}
+	convertToEPUB = false
 )
 
+// init performs early initialization of the CLI layer, handling user-provided flags.
+// It supplements missing flags with standard environment variables. Additionally,
+// it validates that targeted books actually exist on disk, converting their paths to absolute format.
 func init() {
-    flag.StringVar(&SMTP_USER, "u", "", "SMTP server username")
-    flag.StringVar(&SMTP_PASSWD, "p", "", "SMTP server password")
-    flag.StringVar(&SMTP_SERVER, "s", "", "SMTP server")
-    flag.StringVar(&KINDLE_EMAIL, "k", "", "Kindle destination email")
-    flag.BoolVar(&convertToEPUB, "c", false, "Convert to EPUB before sending")
-    flag.Parse()
-    SMTP_USER = FallbackStringVariable("SMTP_USER", SMTP_USER)
-    SMTP_PASSWD = FallbackStringVariable("SMTP_PASSWD", SMTP_PASSWD)
-    SMTP_SERVER = FallbackStringVariable("SMTP_SERVER", SMTP_SERVER)
-    KINDLE_EMAIL = FallbackStringVariable("KINDLE_EMAIL", KINDLE_EMAIL)
-    args := flag.Args()
-    books = make([]string, 0, len(args))
-    for _, book := range args {
-        abs, err := filepath.Abs(book)
-        MustSucess(err)
-        _, err = os.Stat(abs)
-        MustSucess(err)
-        books = append(books, abs)
-    }
-    if len(books) == 0 {
-        Fatalf("No book was specified")
-    }
+	flag.StringVar(&SMTP_USER, "u", "", "SMTP server username")
+	flag.StringVar(&SMTP_PASSWD, "p", "", "SMTP server password")
+	flag.StringVar(&SMTP_SERVER, "s", "", "SMTP server")
+	flag.StringVar(&KINDLE_EMAIL, "k", "", "Kindle destination email")
+	flag.BoolVar(&convertToEPUB, "c", false, "Convert to EPUB before sending")
+	flag.Parse()
+	SMTP_USER = FallbackStringVariable("SMTP_USER", SMTP_USER)
+	SMTP_PASSWD = FallbackStringVariable("SMTP_PASSWD", SMTP_PASSWD)
+	SMTP_SERVER = FallbackStringVariable("SMTP_SERVER", SMTP_SERVER)
+	KINDLE_EMAIL = FallbackStringVariable("KINDLE_EMAIL", KINDLE_EMAIL)
+	args := flag.Args()
+	books = make([]string, 0, len(args))
+	for _, book := range args {
+		abs, err := filepath.Abs(book)
+		MustSucess(err)
+		_, err = os.Stat(abs)
+		MustSucess(err)
+		books = append(books, abs)
+	}
+	if len(books) == 0 {
+		Fatalf("No book was specified")
+	}
 }
 
+// main coordinates the book conversion and dispatch pipeline.
+// It guarantees environmental cleanup via defer before orchestrating format conversion (if required)
+// and calling the SMTP client layer. Failures bubble up to MustSucess for structured logging.
 func main() {
-    defer Cleanup()
-    mail_auth := EmailAuthenticationData{
-        Server: SMTP_SERVER,
-        User: SMTP_USER,
-        Password: SMTP_PASSWD,
-    }
-    if (convertToEPUB) {
-        Log("Converting books to EPUB")
-        for i := 0; i < len(books); i++ {
-            books[i] = ConvertToEPUB(books[i])
-        }
-    }
-    Spew(books)
-    Spew(KINDLE_EMAIL)
-    email := Email{
-        To: KINDLE_EMAIL,
-        Files: books,
-    }
-    Log("Sending email...")
-    MustSucess(SendEmail(mail_auth, email))
-    Log("Done!")
+	defer Cleanup()
+	mail_auth := EmailAuthenticationData{
+		Server:   SMTP_SERVER,
+		User:     SMTP_USER,
+		Password: SMTP_PASSWD,
+	}
+	if convertToEPUB {
+		Log("Converting books to EPUB")
+		for i := 0; i < len(books); i++ {
+			books[i] = ConvertToEPUB(books[i])
+		}
+	}
+	Spew(books)
+	Spew(KINDLE_EMAIL)
+	email := Email{
+		To:    KINDLE_EMAIL,
+		Files: books,
+	}
+	Log("Sending email...")
+	MustSucess(SendEmail(mail_auth, email))
+	Log("Done!")
 }

--- a/cmd/send2kindle/utils.go
+++ b/cmd/send2kindle/utils.go
@@ -8,51 +8,69 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+// MustBinary ensures that a required system binary is available in the current $PATH.
+// It acts as a safety check before executing external commands, terminating the program
+// if the binary cannot be resolved.
 func MustBinary(binary string) {
-    _, err := exec.LookPath(binary)
-    if err != nil {
-        Fatalf("Binary %s not found in $PATH. Aborting...", binary)
-    }
+	_, err := exec.LookPath(binary)
+	if err != nil {
+		Fatalf("Binary %s not found in $PATH. Aborting...", binary)
+	}
 }
 
+// MustSucess acts as the centralized error handler for unrecoverable errors.
+// By wrapping operations with this function, the application guarantees that any failure
+// is logged with context before forcefully exiting.
 func MustSucess(err error) {
-    if err != nil {
-        Fatalf("Fatal error: %s", err)
-    }
+	if err != nil {
+		Fatalf("Fatal error: %s", err)
+	}
 }
 
-// FallbackStringVariable If string is a empty use environment variable, if env variable is a empty panics
+// FallbackStringVariable resolves a configuration value with a fallback mechanism.
+// It first attempts to use the provided default. If empty, it checks the specified environment variable.
+// If both are missing, it triggers a fatal error to prevent the application from running with invalid config.
 func FallbackStringVariable(env string, def string) string {
-    if def != "" {
-        return def
-    }
-    env_value := os.Getenv(env)
-    if env_value != "" {
-        return env_value
-    }
-    Fatalf("Neither %s environment variable nor default value is defined", env)
-    return "" // dead code just to not give compilation errors
+	if def != "" {
+		return def
+	}
+	env_value := os.Getenv(env)
+	if env_value != "" {
+		return env_value
+	}
+	Fatalf("Neither %s environment variable nor default value is defined", env)
+	return "" // dead code just to not give compilation errors
 }
 
+// Fatalf logs a formatted error message and immediately terminates the application.
+// It serves as the primary exit vector for irrecoverable state failures.
 func Fatalf(str string, v ...interface{}) {
-    log.Fatalf(str, v...)
+	log.Fatalf(str, v...)
 }
 
+// Log writes a formatted diagnostic message to standard error.
+// Useful for operational visibility during conversion and email dispatch sequences.
 func Log(str string, v ...interface{}) {
-    log.Printf(str, v...)
+	log.Printf(str, v...)
 }
 
 var showSpewMessages = false
+
+// Spew dumps the deep structure of a given variable if debugging is enabled.
+// It provides a richer, type-aware alternative to standard logging for inspecting complex state.
 func Spew(v interface{}) {
-    if (showSpewMessages) {
-        spew.Dump(v)
-    }
+	if showSpewMessages {
+		spew.Dump(v)
+	}
 }
 
+// Command executes an external binary with the provided arguments, piping stdout and stderr
+// directly to the host's standard streams. It implicitly validates the binary's presence
+// before attempting execution to avoid opaque system errors.
 func Command(binary string, args ...string) error {
-    MustBinary(binary)
-    cmd := exec.Command(binary, args...)
-    cmd.Stderr = os.Stderr
-    cmd.Stdout = os.Stdout
-    return cmd.Run()
+	MustBinary(binary)
+	cmd := exec.Command(binary, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,11 @@
+[tools]
+go = "1.15.15"
+
+[tasks.lint]
+depends = ["lint:*"]
+
+[tasks."lint:vet"]
+run = "go vet ./..."
+
+[tasks."lint:fmt"]
+run = "gofmt -s -w ."


### PR DESCRIPTION
This PR documents the primary `send2kindle` package functions to establish a baseline of high-quality documentation for LLMs and developers.

### Scope and Changes
*   Added rich docstrings to files under `cmd/send2kindle/` detailing nuances like error propagation strategies and side-effects (like temp file creation).
*   Followed the project convention to avoid obvious or generic comments.
*   Added `AGENTS.md` to act as the source of truth for architectural structure and development rules.
*   Added `.mise.toml` to satisfy the strictly required `mise run lint` tooling.

### Assumptions
*   It is assumed that the `ebook-convert` system binary is a hard dependency running outside the Go process and we only need to document its invocation.

### Alternatives Not Chosen
*   Generating documentation for Nix packaging definitions, as these were deemed less critical to document during the first pass of Golang logic documentation.

### How To Pivot
*   If `mise.toml` is considered entirely out-of-scope for a docs-only patch, it can be reverted and its task definitions ported directly to `.github/workflows` or a shell script.

### Next Knobs
*   Adding equivalent docstrings for `shell.nix` and `package.nix` update logic.
*   Migrating the hardcoded system exit `MustSucess` calls into returning Go errors up to `main()`.

---
*PR created automatically by Jules for task [4305044389325465397](https://jules.google.com/task/4305044389325465397) started by @lucasew*