### PR TITLE
🛡️ Sentinel: [Medium] Fix swallowed os.Remove error in cleanup hook

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-16: [Medium] Swallowed errors in cleanup routines mask underlying resource leaks or permission issues.

--- a/cmd/send2kindle/cleanup.go
+++ b/cmd/send2kindle/cleanup.go
@@ -13,7 +13,9 @@ func CreateTempFileName(extension string) (filename string) {
     generatedName := uuid.New().String()
     filename = path.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
     AddCleanupHook(func() {
-        os.Remove(filename)
+        if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
+            Log("Failed to remove temporary file %s: %v", filename, err)
+        }
     })
     return filename
 }

--- a/cmd/send2kindle/cleanup.go
+++ b/cmd/send2kindle/cleanup.go
@@ -9,27 +9,27 @@ import (
 )
 
 func CreateTempFileName(extension string) (filename string) {
-    tmpdir := os.TempDir()
-    generatedName := uuid.New().String()
-    filename = path.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
-    AddCleanupHook(func() {
-        if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
-            Log("Failed to remove temporary file %s: %v", filename, err)
-        }
-    })
-    return filename
+	tmpdir := os.TempDir()
+	generatedName := uuid.New().String()
+	filename = path.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
+	AddCleanupHook(func() {
+		if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
+			Log("Failed to remove temporary file %s: %v", filename, err)
+		}
+	})
+	return filename
 }
 
 var (
-    cleanupHooks = []func(){}
+	cleanupHooks = []func(){}
 )
 
 func AddCleanupHook(f func()) {
-    cleanupHooks = append(cleanupHooks, f)
+	cleanupHooks = append(cleanupHooks, f)
 }
 
 func Cleanup() {
-    for _, f := range cleanupHooks {
-        f()
-    }
+	for _, f := range cleanupHooks {
+		f()
+	}
 }

--- a/cmd/send2kindle/convert.go
+++ b/cmd/send2kindle/convert.go
@@ -1,8 +1,8 @@
 package main
 
 func ConvertToEPUB(filename string) string {
-    outputFileName := CreateTempFileName("epub")
-    Log("Converting '%s' to '%s'", filename, outputFileName)
-    MustSucess(Command("ebook-convert", filename, outputFileName))
-    return outputFileName
+	outputFileName := CreateTempFileName("epub")
+	Log("Converting '%s' to '%s'", filename, outputFileName)
+	MustSucess(Command("ebook-convert", filename, outputFileName))
+	return outputFileName
 }

--- a/cmd/send2kindle/mail.go
+++ b/cmd/send2kindle/mail.go
@@ -9,33 +9,33 @@ import (
 )
 
 type Email struct {
-    To string
-    Files []string
+	To    string
+	Files []string
 }
 
 type EmailAuthenticationData struct {
-    Server string
-    User string
-    Password string
+	Server   string
+	User     string
+	Password string
 }
 
 func SendEmail(s EmailAuthenticationData, msgs ...Email) error {
-    serverOnly := strings.Split(s.Server, ":")[0]
-    auth := smtp.PlainAuth("", s.User, s.Password, serverOnly)
-    for _, msg := range msgs {
-        m := email.NewMessage("", "")
-        m.To = []string{msg.To}
-        m.From = mail.Address{Name: "", Address: s.User}
-        for _, file := range msg.Files {
-            err := m.Attach(file)
-            if err != nil {
-                return err
-            }
-        }
-        err := email.Send(s.Server, auth, m)
-        if err != nil {
-            return err
-        }
-    }
-    return nil
+	serverOnly := strings.Split(s.Server, ":")[0]
+	auth := smtp.PlainAuth("", s.User, s.Password, serverOnly)
+	for _, msg := range msgs {
+		m := email.NewMessage("", "")
+		m.To = []string{msg.To}
+		m.From = mail.Address{Name: "", Address: s.User}
+		for _, file := range msg.Files {
+			err := m.Attach(file)
+			if err != nil {
+				return err
+			}
+		}
+		err := email.Send(s.Server, auth, m)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/send2kindle/main.go
+++ b/cmd/send2kindle/main.go
@@ -7,62 +7,62 @@ import (
 )
 
 var ( // Authentication parameters
-    SMTP_USER = ""
-    SMTP_PASSWD = ""
-    SMTP_SERVER = ""
-    KINDLE_EMAIL = ""
+	SMTP_USER    = ""
+	SMTP_PASSWD  = ""
+	SMTP_SERVER  = ""
+	KINDLE_EMAIL = ""
 )
 
 var (
-    books = []string{}
-    convertToEPUB = false
+	books         = []string{}
+	convertToEPUB = false
 )
 
 func init() {
-    flag.StringVar(&SMTP_USER, "u", "", "SMTP server username")
-    flag.StringVar(&SMTP_PASSWD, "p", "", "SMTP server password")
-    flag.StringVar(&SMTP_SERVER, "s", "", "SMTP server")
-    flag.StringVar(&KINDLE_EMAIL, "k", "", "Kindle destination email")
-    flag.BoolVar(&convertToEPUB, "c", false, "Convert to EPUB before sending")
-    flag.Parse()
-    SMTP_USER = FallbackStringVariable("SMTP_USER", SMTP_USER)
-    SMTP_PASSWD = FallbackStringVariable("SMTP_PASSWD", SMTP_PASSWD)
-    SMTP_SERVER = FallbackStringVariable("SMTP_SERVER", SMTP_SERVER)
-    KINDLE_EMAIL = FallbackStringVariable("KINDLE_EMAIL", KINDLE_EMAIL)
-    args := flag.Args()
-    books = make([]string, 0, len(args))
-    for _, book := range args {
-        abs, err := filepath.Abs(book)
-        MustSucess(err)
-        _, err = os.Stat(abs)
-        MustSucess(err)
-        books = append(books, abs)
-    }
-    if len(books) == 0 {
-        Fatalf("No book was specified")
-    }
+	flag.StringVar(&SMTP_USER, "u", "", "SMTP server username")
+	flag.StringVar(&SMTP_PASSWD, "p", "", "SMTP server password")
+	flag.StringVar(&SMTP_SERVER, "s", "", "SMTP server")
+	flag.StringVar(&KINDLE_EMAIL, "k", "", "Kindle destination email")
+	flag.BoolVar(&convertToEPUB, "c", false, "Convert to EPUB before sending")
+	flag.Parse()
+	SMTP_USER = FallbackStringVariable("SMTP_USER", SMTP_USER)
+	SMTP_PASSWD = FallbackStringVariable("SMTP_PASSWD", SMTP_PASSWD)
+	SMTP_SERVER = FallbackStringVariable("SMTP_SERVER", SMTP_SERVER)
+	KINDLE_EMAIL = FallbackStringVariable("KINDLE_EMAIL", KINDLE_EMAIL)
+	args := flag.Args()
+	books = make([]string, 0, len(args))
+	for _, book := range args {
+		abs, err := filepath.Abs(book)
+		MustSucess(err)
+		_, err = os.Stat(abs)
+		MustSucess(err)
+		books = append(books, abs)
+	}
+	if len(books) == 0 {
+		Fatalf("No book was specified")
+	}
 }
 
 func main() {
-    defer Cleanup()
-    mail_auth := EmailAuthenticationData{
-        Server: SMTP_SERVER,
-        User: SMTP_USER,
-        Password: SMTP_PASSWD,
-    }
-    if (convertToEPUB) {
-        Log("Converting books to EPUB")
-        for i := 0; i < len(books); i++ {
-            books[i] = ConvertToEPUB(books[i])
-        }
-    }
-    Spew(books)
-    Spew(KINDLE_EMAIL)
-    email := Email{
-        To: KINDLE_EMAIL,
-        Files: books,
-    }
-    Log("Sending email...")
-    MustSucess(SendEmail(mail_auth, email))
-    Log("Done!")
+	defer Cleanup()
+	mail_auth := EmailAuthenticationData{
+		Server:   SMTP_SERVER,
+		User:     SMTP_USER,
+		Password: SMTP_PASSWD,
+	}
+	if convertToEPUB {
+		Log("Converting books to EPUB")
+		for i := 0; i < len(books); i++ {
+			books[i] = ConvertToEPUB(books[i])
+		}
+	}
+	Spew(books)
+	Spew(KINDLE_EMAIL)
+	email := Email{
+		To:    KINDLE_EMAIL,
+		Files: books,
+	}
+	Log("Sending email...")
+	MustSucess(SendEmail(mail_auth, email))
+	Log("Done!")
 }

--- a/cmd/send2kindle/utils.go
+++ b/cmd/send2kindle/utils.go
@@ -9,50 +9,51 @@ import (
 )
 
 func MustBinary(binary string) {
-    _, err := exec.LookPath(binary)
-    if err != nil {
-        Fatalf("Binary %s not found in $PATH. Aborting...", binary)
-    }
+	_, err := exec.LookPath(binary)
+	if err != nil {
+		Fatalf("Binary %s not found in $PATH. Aborting...", binary)
+	}
 }
 
 func MustSucess(err error) {
-    if err != nil {
-        Fatalf("Fatal error: %s", err)
-    }
+	if err != nil {
+		Fatalf("Fatal error: %s", err)
+	}
 }
 
 // FallbackStringVariable If string is a empty use environment variable, if env variable is a empty panics
 func FallbackStringVariable(env string, def string) string {
-    if def != "" {
-        return def
-    }
-    env_value := os.Getenv(env)
-    if env_value != "" {
-        return env_value
-    }
-    Fatalf("Neither %s environment variable nor default value is defined", env)
-    return "" // dead code just to not give compilation errors
+	if def != "" {
+		return def
+	}
+	env_value := os.Getenv(env)
+	if env_value != "" {
+		return env_value
+	}
+	Fatalf("Neither %s environment variable nor default value is defined", env)
+	return "" // dead code just to not give compilation errors
 }
 
 func Fatalf(str string, v ...interface{}) {
-    log.Fatalf(str, v...)
+	log.Fatalf(str, v...)
 }
 
 func Log(str string, v ...interface{}) {
-    log.Printf(str, v...)
+	log.Printf(str, v...)
 }
 
 var showSpewMessages = false
+
 func Spew(v interface{}) {
-    if (showSpewMessages) {
-        spew.Dump(v)
-    }
+	if showSpewMessages {
+		spew.Dump(v)
+	}
 }
 
 func Command(binary string, args ...string) error {
-    MustBinary(binary)
-    cmd := exec.Command(binary, args...)
-    cmd.Stderr = os.Stderr
-    cmd.Stdout = os.Stdout
-    return cmd.Run()
+	MustBinary(binary)
+	cmd := exec.Command(binary, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
 }


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** Ignored/swallowed errors
**Impact:** Swallowed errors in cleanup routines mask underlying resource leaks or permission issues, preventing them from being detected or debugged efficiently.
**Fix:** Modified `AddCleanupHook` in `cmd/send2kindle/cleanup.go` to capture and log the error returned by `os.Remove(filename)` using the centralized `Log` function. The `os.IsNotExist` error is safely ignored to prevent false positives when the file is successfully deleted.
**Verification:** Validated that the modified project builds correctly and passes Go unit tests.

### Assumptions
- The centralized `Log` function handles logging errors adequately for the application runtime.
- A missing temporary file (`os.IsNotExist(err)`) during a cleanup operation does not constitute an unexpected error state.

### Alternatives Not Chosen
- Returning errors from the `cleanupHooks` and attempting error aggregation in `main()` was rejected in favor of inline logging, to minimize structural changes and maintain simplicity.

### How To Pivot
If an aggregated error reporting pattern is preferred, the `cleanupHooks` signature can be updated to `func() error` and the results collected inside `Cleanup()`.

### Next Knobs
- Adjust the error conditions ignored, such as ignoring permission denied instead of strictly `os.IsNotExist`.
- Wire `Log` to an external observability tool (like Sentry) within `cmd/send2kindle/utils.go`.

---
*PR created automatically by Jules for task [16277740996902592896](https://jules.google.com/task/16277740996902592896) started by @lucasew*