### PR TITLE
📝 Docs: Add comprehensive documentation for mail delivery module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agents Operational Memory & Project Conventions
+
+This file provides historical context, codebase navigation, and guidelines for Agents working on the project.
+
+## Architecture & Code Map
+* Entry point -> `cmd/send2kindle/main.go`
+* External binary calls -> `MustBinary` and `Command` in `cmd/send2kindle/utils.go`
+* Centralized error handling / logging -> `Fatalf` / `Log` in `cmd/send2kindle/utils.go`
+* Email logic -> `cmd/send2kindle/mail.go`
+* EPUB Conversion -> `cmd/send2kindle/convert.go`
+* Temporary files and cleanup -> `AddCleanupHook` and `Cleanup()` in `cmd/send2kindle/cleanup.go`
+* Dependency management -> Go modules + Nix (`package.nix` / `shell.nix`)
+* Task runner -> `mise` via `mise.toml`
+
+## Project Rules
+1. **Never ignore/swallow errors.** Empty `catch` blocks or ignored return errors are retroactive violations and treated as medium-priority security issues.
+2. Route all unexpected errors through centralized reporting (e.g. `Fatalf` or `Log` in `cmd/send2kindle/utils.go`).
+3. Always pin tool versions (e.g. `mise.toml` requires a specific Go version like `1.15.0`).
+4. Avoid line comments (`//`) when writing documentation docstrings (`/* ... */`).
+5. Ensure external dependencies (like `ebook-convert`) are validated through `MustBinary` before use.

--- a/cmd/send2kindle/mail.go
+++ b/cmd/send2kindle/mail.go
@@ -8,34 +8,55 @@ import (
 	"github.com/scorredoira/email"
 )
 
+/**
+ * Represents the final payload destined for the Kindle device.
+ * `Files` should contain fully-qualified paths to the processed book files
+ * (post-conversion, if applicable).
+ */
 type Email struct {
-    To string
-    Files []string
+	To    string
+	Files []string
 }
 
+/**
+ * Captures SMTP server details and credentials for dispatching emails.
+ * The `Server` field is expected to include the host and port (e.g. "smtp.example.com:587").
+ */
 type EmailAuthenticationData struct {
-    Server string
-    User string
-    Password string
+	Server   string
+	User     string
+	Password string
 }
 
+/**
+ * Orchestrates the dispatch of one or more Email payloads through the provided SMTP relay.
+ * This function iterates over messages, attaching multiple books if requested, and blocks
+ * until all emails are dispatched or an attachment/transmission error occurs.
+ *
+ * Side effects:
+ * - Reads from disk (for every file listed in the `Files` slice).
+ * - Opens a network connection to the defined SMTP server.
+ *
+ * It terminates early on the first attachment failure or SMTP error, returning it upstream
+ * where it is typically expected to be routed through the centralized MustSuccess/Fatalf.
+ */
 func SendEmail(s EmailAuthenticationData, msgs ...Email) error {
-    serverOnly := strings.Split(s.Server, ":")[0]
-    auth := smtp.PlainAuth("", s.User, s.Password, serverOnly)
-    for _, msg := range msgs {
-        m := email.NewMessage("", "")
-        m.To = []string{msg.To}
-        m.From = mail.Address{Name: "", Address: s.User}
-        for _, file := range msg.Files {
-            err := m.Attach(file)
-            if err != nil {
-                return err
-            }
-        }
-        err := email.Send(s.Server, auth, m)
-        if err != nil {
-            return err
-        }
-    }
-    return nil
+	serverOnly := strings.Split(s.Server, ":")[0]
+	auth := smtp.PlainAuth("", s.User, s.Password, serverOnly)
+	for _, msg := range msgs {
+		m := email.NewMessage("", "")
+		m.To = []string{msg.To}
+		m.From = mail.Address{Name: "", Address: s.User}
+		for _, file := range msg.Files {
+			err := m.Attach(file)
+			if err != nil {
+				return err
+			}
+		}
+		err := email.Send(s.Server, auth, m)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
# Goal
Add or improve docstrings (`/** ... */`) to generate value for both humans and LLMs, focusing on one cohesive area per PR without changing executable logic. The area chosen was the mail delivery logic in `cmd/send2kindle/mail.go`.

# Assumptions
- It's better to bootstrap the conventions file `AGENTS.md` from scratch since it didn't exist, rather than ignoring the global instructions that mandate it.
- Block comments `/** ... */` were strictly used instead of standard Go line comments `//` because of the explicit prompt requirement: "Avoid line comments (`//`) unless inside function bodies."

# Alternatives Not Chosen
- I could have also added docstrings to the entry point `main.go`, but that would risk violating the scope constraint of focusing on exactly ONE cohesive area (the mail module).
- Using standard Go `//` comments. This was rejected due to explicit contradictory instruction.

# How To Pivot
If `/** ... */` syntax is strongly undesired because it breaks standard `godoc`, revert the PR, or modify the patch to use standard `//` comments. Since the changes are purely superficial, you can quickly run `sed -i 's/\/\*\*/\/\//g'` over the file to begin the transition.

# Next Knobs
- **Files:** Additional documentation can be targeted to `cmd/send2kindle/utils.go` in a subsequent PR.
- **AGENTS.md:** More conventions can be added to the newly created file as other agents interact with the repository.

---
*PR created automatically by Jules for task [16941782340285676750](https://jules.google.com/task/16941782340285676750) started by @lucasew*