### PR TITLE
🛡️ Sentinel: [High] Secure temporary file creation and fix swallowed cleanup error

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,1 +1,1 @@
-- 2026-03-20: [High] Insecure temporary files in shared directories. Look for `os.TempDir()` or `path.Join(os.TempDir(), ...)` used without creating a directory with restrictive permissions (`0700`) first.
+- 2026-03-20: [High] Insecure temporary files in shared directories, spotted by checking if `os.TempDir()` is used directly without creating a restricted-permission directory first.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-20: [High] Insecure temporary files in shared directories. Look for `os.TempDir()` or `path.Join(os.TempDir(), ...)` used without creating a directory with restrictive permissions (`0700`) first.

--- a/cmd/send2kindle/cleanup.go
+++ b/cmd/send2kindle/cleanup.go
@@ -2,32 +2,35 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/google/uuid"
 )
 
 func CreateTempFileName(extension string) (filename string) {
-    tmpdir := os.TempDir()
-    generatedName := uuid.New().String()
-    filename = path.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
-    AddCleanupHook(func() {
-        os.Remove(filename)
-    })
-    return filename
+	tmpdir, err := ioutil.TempDir("", "send2kindle-*")
+	MustSucess(err)
+	generatedName := uuid.New().String()
+	filename = filepath.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
+	AddCleanupHook(func() {
+		err := os.RemoveAll(tmpdir)
+		ReportError(err)
+	})
+	return filename
 }
 
 var (
-    cleanupHooks = []func(){}
+	cleanupHooks = []func(){}
 )
 
 func AddCleanupHook(f func()) {
-    cleanupHooks = append(cleanupHooks, f)
+	cleanupHooks = append(cleanupHooks, f)
 }
 
 func Cleanup() {
-    for _, f := range cleanupHooks {
-        f()
-    }
+	for _, f := range cleanupHooks {
+		f()
+	}
 }

--- a/cmd/send2kindle/cleanup.go
+++ b/cmd/send2kindle/cleanup.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -10,27 +9,27 @@ import (
 )
 
 func CreateTempFileName(extension string) (filename string) {
-	tmpdir, err := ioutil.TempDir("", "send2kindle-*")
-	MustSucess(err)
-	generatedName := uuid.New().String()
-	filename = filepath.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
-	AddCleanupHook(func() {
-		err := os.RemoveAll(tmpdir)
-		ReportError(err)
-	})
-	return filename
+    tmpdir, err := os.MkdirTemp("", "send2kindle-*")
+    MustSucess(err)
+    generatedName := uuid.New().String()
+    filename = filepath.Join(tmpdir, fmt.Sprintf("%s.%s", generatedName, extension))
+    AddCleanupHook(func() {
+        err := os.RemoveAll(tmpdir)
+        ReportError(err)
+    })
+    return filename
 }
 
 var (
-	cleanupHooks = []func(){}
+    cleanupHooks = []func(){}
 )
 
 func AddCleanupHook(f func()) {
-	cleanupHooks = append(cleanupHooks, f)
+    cleanupHooks = append(cleanupHooks, f)
 }
 
 func Cleanup() {
-	for _, f := range cleanupHooks {
-		f()
-	}
+    for _, f := range cleanupHooks {
+        f()
+    }
 }

--- a/cmd/send2kindle/utils.go
+++ b/cmd/send2kindle/utils.go
@@ -9,57 +9,56 @@ import (
 )
 
 func MustBinary(binary string) {
-	_, err := exec.LookPath(binary)
-	if err != nil {
-		Fatalf("Binary %s not found in $PATH. Aborting...", binary)
-	}
+    _, err := exec.LookPath(binary)
+    if err != nil {
+        Fatalf("Binary %s not found in $PATH. Error: %v. Aborting...", binary, err)
+    }
 }
 
 func MustSucess(err error) {
-	if err != nil {
-		Fatalf("Fatal error: %s", err)
-	}
+    if err != nil {
+        Fatalf("Fatal error: %s", err)
+    }
 }
 
 // FallbackStringVariable If string is a empty use environment variable, if env variable is a empty panics
 func FallbackStringVariable(env string, def string) string {
-	if def != "" {
-		return def
-	}
-	env_value := os.Getenv(env)
-	if env_value != "" {
-		return env_value
-	}
-	Fatalf("Neither %s environment variable nor default value is defined", env)
-	return "" // dead code just to not give compilation errors
+    if def != "" {
+        return def
+    }
+    env_value := os.Getenv(env)
+    if env_value != "" {
+        return env_value
+    }
+    Fatalf("Neither %s environment variable nor default value is defined", env)
+    return "" // dead code just to not give compilation errors
 }
 
 func Fatalf(str string, v ...interface{}) {
-	log.Fatalf(str, v...)
+    log.Fatalf(str, v...)
 }
 
 func Log(str string, v ...interface{}) {
-	log.Printf(str, v...)
+    log.Printf(str, v...)
 }
 
 var showSpewMessages = false
-
 func Spew(v interface{}) {
-	if showSpewMessages {
-		spew.Dump(v)
-	}
+    if (showSpewMessages) {
+        spew.Dump(v)
+    }
 }
 
 func Command(binary string, args ...string) error {
-	MustBinary(binary)
-	cmd := exec.Command(binary, args...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	return cmd.Run()
+    MustBinary(binary)
+    cmd := exec.Command(binary, args...)
+    cmd.Stderr = os.Stderr
+    cmd.Stdout = os.Stdout
+    return cmd.Run()
 }
 
 func ReportError(err error) {
-	if err != nil {
-		Log("Error: %s", err)
-	}
+    if err != nil {
+        log.Printf("Reported Error: %v\n", err)
+    }
 }

--- a/cmd/send2kindle/utils.go
+++ b/cmd/send2kindle/utils.go
@@ -9,50 +9,57 @@ import (
 )
 
 func MustBinary(binary string) {
-    _, err := exec.LookPath(binary)
-    if err != nil {
-        Fatalf("Binary %s not found in $PATH. Aborting...", binary)
-    }
+	_, err := exec.LookPath(binary)
+	if err != nil {
+		Fatalf("Binary %s not found in $PATH. Aborting...", binary)
+	}
 }
 
 func MustSucess(err error) {
-    if err != nil {
-        Fatalf("Fatal error: %s", err)
-    }
+	if err != nil {
+		Fatalf("Fatal error: %s", err)
+	}
 }
 
 // FallbackStringVariable If string is a empty use environment variable, if env variable is a empty panics
 func FallbackStringVariable(env string, def string) string {
-    if def != "" {
-        return def
-    }
-    env_value := os.Getenv(env)
-    if env_value != "" {
-        return env_value
-    }
-    Fatalf("Neither %s environment variable nor default value is defined", env)
-    return "" // dead code just to not give compilation errors
+	if def != "" {
+		return def
+	}
+	env_value := os.Getenv(env)
+	if env_value != "" {
+		return env_value
+	}
+	Fatalf("Neither %s environment variable nor default value is defined", env)
+	return "" // dead code just to not give compilation errors
 }
 
 func Fatalf(str string, v ...interface{}) {
-    log.Fatalf(str, v...)
+	log.Fatalf(str, v...)
 }
 
 func Log(str string, v ...interface{}) {
-    log.Printf(str, v...)
+	log.Printf(str, v...)
 }
 
 var showSpewMessages = false
+
 func Spew(v interface{}) {
-    if (showSpewMessages) {
-        spew.Dump(v)
-    }
+	if showSpewMessages {
+		spew.Dump(v)
+	}
 }
 
 func Command(binary string, args ...string) error {
-    MustBinary(binary)
-    cmd := exec.Command(binary, args...)
-    cmd.Stderr = os.Stderr
-    cmd.Stdout = os.Stdout
-    return cmd.Run()
+	MustBinary(binary)
+	cmd := exec.Command(binary, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}
+
+func ReportError(err error) {
+	if err != nil {
+		Log("Error: %s", err)
+	}
 }


### PR DESCRIPTION
### 🛡️ Sentinel: [High] Secure temporary file creation and fix swallowed cleanup error

#### Severity:
High

#### Vulnerability:
Insecure Temporary File Generation (CWE-377). The application created temporary files in the system's shared `/tmp` directory via `os.TempDir()` without enforcing restrictive permissions. Additionally, the cleanup hook swallowed the error returned by `os.Remove()`, which is a retroactive violation of the project's error handling conventions.

#### Impact:
Other local system users could read or potentially tamper with the generated EPUB files in the `/tmp` directory, leading to an exposure of sensitive personal information. Swallowed errors mask potential failures and bugs in the cleanup process.

#### Fix:
1. Replaced `os.TempDir()` with `ioutil.TempDir("", "send2kindle-*")` to ensure that temporary EPUB files are sandboxed inside a newly generated directory with safe `0700` permissions.
2. Modified the cleanup hook from `os.Remove(filename)` to `os.RemoveAll(tmpdir)` to guarantee the entire temporary structure is recursively cleaned up.
3. Created a new, centralized `ReportError` function in `cmd/send2kindle/utils.go` to handle non-fatal errors.
4. Wrapped the `os.RemoveAll` call inside the new `ReportError` function to log any cleanup failures, adhering to the project's strict error reporting rule.
5. Logged the learning pattern into `.jules/sentinel.md`.

#### Verification:
- Automated tests pass successfully (`go test ./...` and `go build ./cmd/send2kindle`).
- The code change correctly addresses both the security concern and the error-swallowing rule violation.

---

### Assumptions
- Generating a private, temporary folder using `ioutil.TempDir` (0700 perms) is the preferred approach for resolving CWE-377, rather than setting restrictive permissions directly on individual generated files, as it inherently protects all internal contents from external directory traversal or snooping.
- `ebook-convert` runs properly under restricted directories created by the parent user process.

### Alternatives Not Chosen
- Modifying file-specific `umask` operations: This approach is often globally scoped to the thread/process and could unpredictably affect other operations. Directory sandboxing is safer.
- Fixing only the swallowed `os.Remove` error (which was already scoped in an open, unmerged PR #27): I pivoted to fixing the core High-priority security vulnerability (`os.TempDir`) to avoid duplicate work while implicitly fixing the error-swallowing violation.

### How To Pivot
If `ioutil.TempDir` causes issues with `ebook-convert` or path lengths on certain OSes:
1. Revert `ioutil.TempDir` back to `os.TempDir()`.
2. Wrap the `os.OpenFile` creation step to pass strict `0600` permissions manually before invoking `ebook-convert`.

### Next Knobs
- **`cmd/send2kindle/cleanup.go`**: Adjust the prefix `"send2kindle-*"` string pattern for temporary folders if a custom format is desired.
- **`cmd/send2kindle/utils.go`**: Enhance the newly introduced `ReportError` function to include context tracking or to dispatch to Sentry if a telemetry backend is ever added.

---
*PR created automatically by Jules for task [1793227764429565460](https://jules.google.com/task/1793227764429565460) started by @lucasew*